### PR TITLE
Kuka offline compiler

### DIFF
--- a/src/Machina/Compilers/CompilerKUKA.cs
+++ b/src/Machina/Compilers/CompilerKUKA.cs
@@ -109,8 +109,6 @@ namespace Machina
             initializationLines.Add(";FOLD BCO INI");  // legacy support for user-programming safety
             initializationLines.Add("GLOBAL INTERRUPT DECL 3 WHEN $STOPMESS==TRUE DO IR_STOPM ( )");  // legacy support for user-programming safety
 
-
-
             initializationLines.Add("INTERRUPT ON 3");
             initializationLines.Add("BAS (#INITMOV,0 )");  // use base function to initialize sys vars to defaults
             initializationLines.Add(";ENDFOLD (BCO INI)");
@@ -121,9 +119,6 @@ namespace Machina
             // so we need these two lines to set the tools back to nothing.
             initializationLines.Add("$BASE = $WORLD; setting of the base coordinate system");
             initializationLines.Add("$TOOL = $NULLFRAME; setting of the tool coordinate system");
-
-
-
 
             // excecuting the BCO movment
             initializationLines.Add("joint_pos_tgt = $axis_act_meas");
@@ -553,10 +548,9 @@ namespace Machina
 
                 case ActionType.AttachTool:
                     ActionAttachTool at = (ActionAttachTool)action;
-                    dec = string.Format("BAS(#TOOL, {0})",
+                    dec = string.Format("  $TOOL = {0}",
                         GetToolValue(cursor));
                     break;
-
 
                 case ActionType.DetachTool:
                     ActionDetachTool ad = (ActionDetachTool)action;

--- a/src/Machina/Compilers/CompilerKUKA.cs
+++ b/src/Machina/Compilers/CompilerKUKA.cs
@@ -117,6 +117,14 @@ namespace Machina
             initializationLines.Add(";ENDFOLD (INI)");
             initializationLines.Add("");
 
+            // by default the controller does not revert the tool back to default
+            // so we need these two lines to set the tools back to nothing.
+            initializationLines.Add("$BASE = $WORLD; setting of the base coordinate system");
+            initializationLines.Add("$TOOL = $NULLFRAME; setting of the tool coordinate system");
+
+
+
+
             // excecuting the BCO movment
             initializationLines.Add("joint_pos_tgt = $axis_act_meas");
             initializationLines.Add("PTP joint_pos_tgt");
@@ -477,6 +485,13 @@ namespace Machina
                         cursor.precision);
                     break;
 
+                // There was no acceleration action
+                case ActionType.Acceleration:
+                    dec = string.Format(CultureInfo.InvariantCulture,
+                        "  $ACC.CP = {0}",
+                        cursor.acceleration / 1000.0);
+                    break;
+
                 // @Aratoo 
                 // creating another case for translation as it should not have ABC euler angles in it.
                 // having angles would mess with the orientation of the robot and result in unexpected movements.
@@ -538,9 +553,10 @@ namespace Machina
 
                 case ActionType.AttachTool:
                     ActionAttachTool at = (ActionAttachTool)action;
-                    dec = string.Format("  $TOOL = {0}",
+                    dec = string.Format("BAS(#TOOL, {0})",
                         GetToolValue(cursor));
                     break;
+
 
                 case ActionType.DetachTool:
                     ActionDetachTool ad = (ActionDetachTool)action;
@@ -640,6 +656,12 @@ namespace Machina
                     dec = string.Format(CultureInfo.InvariantCulture,
                         "  $APO.CDIS = {0}",
                         cursor.precision);
+                    break;
+
+                case ActionType.Acceleration:
+                    dec = string.Format(CultureInfo.InvariantCulture,
+                        "  $ACC.CP = {0}",
+                        cursor.acceleration / 1000.0);
                     break;
 
                 case ActionType.Translation:

--- a/src/Machina/Compilers/CompilerKUKA.cs
+++ b/src/Machina/Compilers/CompilerKUKA.cs
@@ -49,7 +49,7 @@ namespace Machina
             // HEADER file
             RobotProgramFile datFile = new RobotProgramFile(programName, "dat", Encoding, CC);
 
-            /* We might not even need to include any header for a clean program (Arastoo a.khajehee@gmail.com)
+            /* We might not even need to include any header for a clean program (@Arastoo a.khajehee@gmail.com)
              * 
                 List<string> header = new List<string>();
                 header.AddRange(GenerateDisclaimerHeader(programName));
@@ -62,18 +62,18 @@ namespace Machina
 
             /*
              * 
-             * // This line might also be optional (Arastoo)
+             * // This line might also be optional (@Arastoo)
                   header.Add(@"&PARAM DISKPATH = KRC:\R1\Program");  // @TODO: this path should be programmatically generated...
             
              These lines are not needed for an offline program'
-             * We don't need to create an extra DAT file for the offline program to work (Arastoo a.khajehee@gmail.com)
+             * We don't need to create an extra DAT file for the offline program to work (@Arastoo)
                 header.Add(string.Format("DEFDAT  {0}", programName));
                 header.Add("EXT BAS (BAS_COMMAND: IN, REAL: IN)");
                 header.Add("DECL INT SUCCESS");
                 header.Add("ENDDAT");
             */
 
-            /* No need for DAT file (Arastoo a.khajehee@gmail.com)
+            /* No need for DAT file (@Arastoo)
             datFile.SetContent(header);
             robotProgram.Add(datFile);
              */
@@ -140,7 +140,7 @@ namespace Machina
             //initializationLines.Add("  $LOAD.M = 0");   // no mass
             //initializationLines.Add("  $LOAD.CM = {X 0, Y 0, Z 0, A 0, B 0, C 0}");  // no CoG
 
-            // This was reported to be needed (Probably not though (Arastoo Khajehee@gmail.com))
+            // This was reported to be needed (Probably not though (@Arastoo))
             //initializationLines.Add("  BASE_DATA[1] = {X 0, Y 0, Z 0, A 0, B 0, C 0}");
 
             // DATA GENERATION


### PR DESCRIPTION
Merging the changes to the KUKA compiler
Changes are:
[] setting tool and base frame to default
[] Having the default IK configuration to "010" to prevent unwanted turns
[] Changing the move action to only affect the XYZ values and not the ABC values
[] adding KRL acceleration commands, (previously when changing Acceleration only the comment was showing up in KRL)
[] Fixing the difference between PTP C_PTP and LIN C_DIS